### PR TITLE
include the upstream url in config endpoint output

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func createListeners(log *zap.Logger, sd *statsd.Client, cfg *config.Config, ups
 		var local string
 		if strings.Contains(cfg.Network, "unix") {
 			local = fmt.Sprintf("%s%d%s", cfg.LocalSocketPrefix, index, cfg.LocalSocketSuffix)
-			configs = append(configs, fmt.Sprintf("%s||", local))
+			configs = append(configs, fmt.Sprintf("%s|%s|", local, upstream))
 		} else {
 			port := cfg.LocalPortStart + index
 			local = fmt.Sprintf(":%d", port)


### PR DESCRIPTION
There is currently an issue where clients that connect directly to elasticache are unable to properly read values that have been written via memcachedbetween connections. This is because memcached clients use a hash ring with a deterministic hashing function based on the upstream URL to select the cluster member belonging to a given key. memcachedbetween causes the upstreams to look like socket paths (eg, `var/shared/mc-1.sock`) instead of the upstream URLs, so the hash ring is populated differently.

To allow clients to use the original upstream URL in their hashing functions, the change includes it in the config endpoint output. Clients should then parse this out and use it in a customized hashing function.